### PR TITLE
Pull cached image before building image

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ dependencies:
     - curl https://raw.githubusercontent.com/remind101/docker-build/master/docker-build > /home/ubuntu/bin/docker-build
     - chmod +x /home/ubuntu/bin/docker-build
   override:
-    - docker-build pull || docker-build build
+    - docker-build pull || true
+    - docker-build build
 
 deployment:
   hub:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-`docker-build` is a small script for building, tagging and pushing docker images within circle CI. We use this as a way of pre-building Docker images for Tugboat to deploy to Empire.
+`docker-build` is a small script for building, tagging, pushing and pulling docker images within circle CI. We use this as a way of pre-building Docker images for Tugboat to deploy to Empire.
 
 It makes the following assumptions:
 
@@ -38,6 +38,20 @@ $ docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
 $ docker push "$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
 ```
 
+**Pulling the latest image for the branch from the docker registry**
+
+```console
+$ docker-build pull
+```
+
+Equivalent to:
+
+```console
+$ docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+$ docker pull
+"$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_BRANCH"
+```
+
 ### Circle CI
 
 To use this script, merge the following in to your `circle.yml`:
@@ -52,7 +66,7 @@ dependencies:
     - curl https://raw.githubusercontent.com/remind101/docker-build/master/docker-build > /home/ubuntu/bin/docker-build
     - chmod +x /home/ubuntu/bin/docker-build
   override:
-    - docker-build build
+    - docker-build pull || docker-build build
 
 deployment:
   hub:

--- a/docker-build
+++ b/docker-build
@@ -4,6 +4,7 @@ set -e
 
 # The docker repo.
 REPO="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
+CACHE_PREFIX="cache"
 
 # Usage prints the help for this command.
 usage() {
@@ -13,7 +14,7 @@ usage() {
   echo "Commands:"
   echo "    build  Build a docker image from this repo and tag it with the git sha and branch"
   echo "    push   Push the built image to the docker registry. \$DOCKER_EMAIL, \$DOCKER_USER, and \$DOCKER_PASS are required"
-  echo "    pull   Pull the previously built image from the docker registry. \$DOCKER_EMAIL, \$DOCKER_USER, and \$DOCKER_PASS are required"
+  echo "    pull   Pull the cached image from the docker registry. \$DOCKER_EMAIL, \$DOCKER_USER, and \$DOCKER_PASS are required"
   exit 2
 }
 
@@ -33,6 +34,7 @@ build() {
   docker build --no-cache -t "$repo" .
   docker tag "$repo" "${repo}:${sha}"
   docker tag "$repo" "${repo}:${branch}"
+  docker tag "$repo" "${repo}:${CACHE_PREFIX}-${branch}"
   if [ -n "$tag" ]; then
     docker tag "$repo" "${repo}:${tag}"
   fi
@@ -59,7 +61,7 @@ pull() {
   fi
 
   login
-  docker pull "$repo:$branch"
+  docker pull "$repo:${CACHE_PREFIX}-$branch"
 }
 case "$1" in
   "build")

--- a/docker-build
+++ b/docker-build
@@ -34,7 +34,7 @@ build() {
   docker build -t "$repo" .
   docker tag "$repo" "${repo}:${sha}"
   docker tag "$repo" "${repo}:${branch}"
-  docker tag "$repo" "${repo}:${CACHE_PREFIX}-${branch}"
+  docker tag -f "$repo" "${repo}:${CACHE_PREFIX}-${branch}"
   if [ -n "$tag" ]; then
     docker tag "$repo" "${repo}:${tag}"
   fi

--- a/docker-build
+++ b/docker-build
@@ -13,6 +13,7 @@ usage() {
   echo "Commands:"
   echo "    build  Build a docker image from this repo and tag it with the git sha and branch"
   echo "    push   Push the built image to the docker registry. \$DOCKER_EMAIL, \$DOCKER_USER, and \$DOCKER_PASS are required"
+  echo "    pull   Pull the previously built image from the docker registry. \$DOCKER_EMAIL, \$DOCKER_USER, and \$DOCKER_PASS are required"
   exit 1
 }
 
@@ -44,12 +45,30 @@ push() {
   docker push "$repo"
 }
 
+# Pull pulls the built docker image for the branch.
+pull() {
+  declare repo="$1" registry="$2" branch="$CIRCLE_BRANCH"
+
+  if [ -n "$registry" ]; then
+    repo=$registry/$repo
+  fi
+
+  if [ -z "$DOCKER_EMAIL" ] || [ -z "$DOCKER_USER" ] || [ -z "$DOCKER_PASS" ]; then
+    usage
+  fi
+
+  docker login -e "$DOCKER_EMAIL" -u "$DOCKER_USER" -p "$DOCKER_PASS"
+  docker pull "$repo:$branch"
+}
 case "$1" in
   "build")
     build "$REPO"
     ;;
   "push")
     push "$REPO" "$DOCKER_REGISTRY"
+    ;;
+  "pull")
+    pull "$REPO" "$DOCKER_REGISTRY"
     ;;
   *)
     usage

--- a/docker-build
+++ b/docker-build
@@ -35,8 +35,8 @@ build() {
   docker tag "$repo" "${repo}:${sha}"
   docker tag "$repo" "${repo}:${branch}"
   docker tag -f "$repo" "${repo}:${CACHE_PREFIX}-${branch}"
-  if [ -n "$tag" ]; then
-    docker tag "$repo" "${repo}:${tag}"
+  if [ -n "$tag" -a "$branch" != "$tag" ]; then
+    docker tag -f "$repo" "${repo}:${tag}"
   fi
 }
 

--- a/docker-build
+++ b/docker-build
@@ -31,7 +31,7 @@ login() {
 build() {
   declare repo="$1" sha="$CIRCLE_SHA1" branch="$CIRCLE_BRANCH"
   declare tag=`git describe --tags --exact-match $CIRCLE_SHA1 2>/dev/null`
-  docker build --no-cache -t "$repo" .
+  docker build -t "$repo" .
   docker tag "$repo" "${repo}:${sha}"
   docker tag "$repo" "${repo}:${branch}"
   docker tag "$repo" "${repo}:${CACHE_PREFIX}-${branch}"

--- a/docker-build
+++ b/docker-build
@@ -17,6 +17,15 @@ usage() {
   exit 1
 }
 
+# Login to repository
+login() {
+  if [ -z "$DOCKER_EMAIL" ] || [ -z "$DOCKER_USER" ] || [ -z "$DOCKER_PASS" ]; then
+    usage
+  fi
+
+  docker login -e "$DOCKER_EMAIL" -u "$DOCKER_USER" -p "$DOCKER_PASS"
+}
+
 # Build builds the docker image and tags it with the git sha and branch.
 build() {
   declare repo="$1" sha="$CIRCLE_SHA1" branch="$CIRCLE_BRANCH"
@@ -37,11 +46,7 @@ push() {
     repo=$registry/$repo
   fi
 
-  if [ -z "$DOCKER_EMAIL" ] || [ -z "$DOCKER_USER" ] || [ -z "$DOCKER_PASS" ]; then
-    usage
-  fi
-
-  docker login -e "$DOCKER_EMAIL" -u "$DOCKER_USER" -p "$DOCKER_PASS"
+  login
   docker push "$repo"
 }
 
@@ -53,11 +58,7 @@ pull() {
     repo=$registry/$repo
   fi
 
-  if [ -z "$DOCKER_EMAIL" ] || [ -z "$DOCKER_USER" ] || [ -z "$DOCKER_PASS" ]; then
-    usage
-  fi
-
-  docker login -e "$DOCKER_EMAIL" -u "$DOCKER_USER" -p "$DOCKER_PASS"
+  login
   docker pull "$repo:$branch"
 }
 case "$1" in

--- a/docker-build
+++ b/docker-build
@@ -14,7 +14,7 @@ usage() {
   echo "    build  Build a docker image from this repo and tag it with the git sha and branch"
   echo "    push   Push the built image to the docker registry. \$DOCKER_EMAIL, \$DOCKER_USER, and \$DOCKER_PASS are required"
   echo "    pull   Pull the previously built image from the docker registry. \$DOCKER_EMAIL, \$DOCKER_USER, and \$DOCKER_PASS are required"
-  exit 1
+  exit 2
 }
 
 # Login to repository


### PR DESCRIPTION
Small improvement we did to `docker-build`. Includes handling tags better, especially when a CI build is triggered explicitly for a tag.