### PR TITLE
Allow supplying the docker registry repo as the first argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 It makes the following assumptions:
 
-1. Either your docker registry repo and GitHub repo are the same (e.g. remind101/acme-inc on GitHub, remind101/acme-inc on Docker registry), or you provide the docker registry repo as the first argument to *all* commands.
+1. Either your docker registry repo and GitHub repo are the same (e.g. remind101/acme-inc on GitHub, remind101/acme-inc on Docker registry), or you provide `$DOCKER_REGISTRY_USERNAME` and `$DOCKER_REGISTRY_REPONAME`.
 2. You want to tag the docker image with the value of the `$CIRLE_SHA1` (git commit sha) and `$CIRCLE_BRANCH` (git branch).
 3. You're docker credentials are provided as `$DOCKER_EMAIL`, `$DOCKER_USER`, `$DOCKER_PASS`
 4. If you're using a different registry than DockerHub then `$DOCKER_REGISTRY` is set. Please see [this blog post][private_registry] on the format of the registry url.
@@ -34,19 +34,6 @@ $ docker-build build --build-arg AWS_ACCESS_KEY_ID=ACDCABBA
 Equivalent to:
 ```console
 $ docker build --no-cache --build-arg AWS_ACCESS_KEY_ID=ACDCABBA -t "$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME" .
-...
-```
-
-
-You can also manually set the docker registry repo name:
-
-```console
-$ docker-build build sspinc/docker-registry-repo-name
-```
-
-Equivalent to:
-```console
-$ docker build --no-cache -t "sspinc/docker-registry-repo-name" .
 ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 It makes the following assumptions:
 
-1. Your docker registry repo and GitHub repo are the same (e.g. remind101/acme-inc on GitHub, remind101/acme-inc on Docker registry).
+1. Either your docker registry repo and GitHub repo are the same (e.g. remind101/acme-inc on GitHub, remind101/acme-inc on Docker registry), or you provide the docker registry repo as the first argument to *all* commands.
 2. You want to tag the docker image with the value of the `$CIRLE_SHA1` (git commit sha) and `$CIRCLE_BRANCH` (git branch).
 3. You're docker credentials are provided as `$DOCKER_EMAIL`, `$DOCKER_USER`, `$DOCKER_PASS`
 4. If you're using a different registry than DockerHub then `$DOCKER_REGISTRY` is set. Please see [this blog post][private_registry] on the format of the registry url.
@@ -37,6 +37,19 @@ $ docker build --no-cache --build-arg AWS_ACCESS_KEY_ID=ACDCABBA -t "$CIRCLE_PRO
 ...
 ```
 
+
+You can also manually set the docker registry repo name:
+
+```console
+$ docker-build build sspinc/docker-registry-repo-name
+```
+
+Equivalent to:
+```console
+$ docker build --no-cache -t "sspinc/docker-registry-repo-name" .
+...
+```
+
 **Push the resulting image to docker registry**
 
 ```console
@@ -60,8 +73,7 @@ Equivalent to:
 
 ```console
 $ docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
-$ docker pull
-"$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_BRANCH"
+$ docker pull "$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_BRANCH"
 ```
 
 ### Circle CI

--- a/docker-build
+++ b/docker-build
@@ -3,7 +3,7 @@
 set -e
 
 # The docker repo.
-REPO="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
+REPO="${DOCKER_REGISTRY_USERNAME:-$CIRCLE_PROJECT_USERNAME}/${DOCKER_REGISTRY_REPONAME:-$CIRCLE_PROJECT_REPONAME}"
 CACHE_PREFIX="cache"
 
 # Usage prints the help for this command.
@@ -67,13 +67,13 @@ pull() {
 case "$1" in
   "build")
     shift
-    build "${2:-$REPO}" "$@"
+    build "$REPO" "$@"
     ;;
   "push")
-    push "${2:-$REPO}" "$DOCKER_REGISTRY"
+    push "$REPO" "$DOCKER_REGISTRY"
     ;;
   "pull")
-    pull "${2:-$REPO}" "$DOCKER_REGISTRY"
+    pull "$REPO" "$DOCKER_REGISTRY"
     ;;
   *)
     usage

--- a/docker-build
+++ b/docker-build
@@ -67,13 +67,13 @@ pull() {
 case "$1" in
   "build")
     shift
-    build "$REPO" "$@"
+    build "${2:-$REPO}" "$@"
     ;;
   "push")
-    push "$REPO" "$DOCKER_REGISTRY"
+    push "${2:-$REPO}" "$DOCKER_REGISTRY"
     ;;
   "pull")
-    pull "$REPO" "$DOCKER_REGISTRY"
+    pull "${2:-$REPO}" "$DOCKER_REGISTRY"
     ;;
   *)
     usage


### PR DESCRIPTION
Either this, or we could also allow configuring this from two environment variables that would take precedence over `CIRCLE_PROJECT_USERNAME` and `CIRCLE_PROJECT_REPONAME`. Something like `DOCKER_REGISTRY_USERNAME` and `DOCKER_REGISTRY_REPONAME`. I'd might actually prefer that. @tmichel what do you think?